### PR TITLE
Reduce code duplication by extracting shared helpers

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -83,11 +83,8 @@ impl Catalog {
                     out.push_str(&format!("  /** {desc} */\n"));
                 }
                 // Quote tool names that aren't valid identifiers.
-                let name_str = if is_valid_js_ident(&tool.name) {
-                    format!("{name}(params: {{ {params_type} }}): Promise<any>;", name = tool.name)
-                } else {
-                    format!("\"{name}\"(params: {{ {params_type} }}): Promise<any>;", name = tool.name)
-                };
+                let prop_name = js_property_name(&tool.name);
+                let name_str = format!("{prop_name}(params: {{ {params_type} }}): Promise<any>;");
                 out.push_str(&format!("  {name_str}\n"));
             }
             out.push_str("};\n\n");
@@ -134,11 +131,7 @@ fn schema_to_ts_params(schema: &serde_json::Value) -> String {
             "?"
         };
         // Quote property names that aren't valid JS identifiers.
-        let name_str = if is_valid_js_ident(name) {
-            format!("{name}{optional}")
-        } else {
-            format!("\"{name}\"{optional}")
-        };
+        let name_str = format!("{}{optional}", js_property_name(name));
         params.push(format!("{name_str}: {ts_type}"));
     }
 
@@ -190,6 +183,10 @@ fn json_type_to_ts(schema: &serde_json::Value) -> String {
         }
         _ => "any".to_string(),
     }
+}
+
+fn js_property_name(name: &str) -> String {
+    if is_valid_js_ident(name) { name.to_string() } else { format!("\"{name}\"") }
 }
 
 /// Check if a string is a valid JavaScript identifier (simplified).

--- a/src/transpile.rs
+++ b/src/transpile.rs
@@ -7,6 +7,12 @@ use oxc::semantic::SemanticBuilder;
 use oxc::span::SourceType;
 use oxc::transformer::{TransformOptions, Transformer};
 
+fn fmt_errors<E: std::fmt::Display>(label: &str, errors: &[E]) -> Result<(), String> {
+    if errors.is_empty() { return Ok(()); }
+    let msgs: Vec<String> = errors.iter().map(|e| format!("{e}")).collect();
+    Err(format!("{label}: {}", msgs.join("; ")))
+}
+
 /// Transpile TypeScript to JavaScript by stripping type annotations.
 pub fn ts_to_js(source: &str) -> Result<String, String> {
     let allocator = Allocator::default();
@@ -15,30 +21,21 @@ pub fn ts_to_js(source: &str) -> Result<String, String> {
 
     // Parse
     let parser_ret = Parser::new(&allocator, source, source_type).parse();
-    if !parser_ret.errors.is_empty() {
-        let msgs: Vec<String> = parser_ret.errors.iter().map(|e| format!("{e}")).collect();
-        return Err(format!("parse error: {}", msgs.join("; ")));
-    }
+    fmt_errors("parse error", &parser_ret.errors)?;
     let mut program = parser_ret.program;
 
     // Semantic analysis (required by transformer)
     let semantic_ret = SemanticBuilder::new()
         .with_excess_capacity(2.0)
         .build(&program);
-    if !semantic_ret.errors.is_empty() {
-        let msgs: Vec<String> = semantic_ret.errors.iter().map(|e| format!("{e}")).collect();
-        return Err(format!("semantic error: {}", msgs.join("; ")));
-    }
+    fmt_errors("semantic error", &semantic_ret.errors)?;
     let scoping = semantic_ret.semantic.into_scoping();
 
     // Transform (strip types)
     let options = TransformOptions::default();
     let transform_ret = Transformer::new(&allocator, path, &options)
         .build_with_scoping(scoping, &mut program);
-    if !transform_ret.errors.is_empty() {
-        let msgs: Vec<String> = transform_ret.errors.iter().map(|e| format!("{e}")).collect();
-        return Err(format!("transform error: {}", msgs.join("; ")));
-    }
+    fmt_errors("transform error", &transform_ret.errors)?;
 
     // Codegen
     let js = Codegen::new().build(&program).code;


### PR DESCRIPTION
- catalog: extract js_property_name() for quoting JS identifiers
- client: merge identical Http/Sse match arms; extract make_params closure
- main: extract format_transport_info(), print_server_saved(); merge parse_headers/parse_envs into parse_key_value()
- server: extract user_config_mtime() helper
- transpile: extract fmt_errors() to unify error-formatting pattern