### PR TITLE
feat(serve): started upstream initialization in background

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,9 @@ Claude/Codex  ──stdio──▶  CodeModeServer (server.rs)
 
 **Source files** (all in `src/`):
 - `main.rs` — CLI entry point with Clap subcommands, all `cmd_*` handler functions
-- `server.rs` — MCP server exposing `search`+`execute`, hot-reload via config mtime checking
+- `server.rs` — MCP server exposing `search`+`execute`, starts upstream initialization in the background, hot-reload via config mtime checking
 - `client.rs` — `ClientPool` connecting to upstream MCP servers, one reconnect retry on failure
-- `catalog.rs` — Aggregates tools from all servers, generates TS type declarations from JSON Schema
+- `catalog.rs` — Aggregates tools from all ready servers, generates TS type declarations from JSON Schema
 - `sandbox.rs` — QuickJS sandbox, wraps agent code in async function, provides `call_tool` bridge
 - `transpile.rs` — oxc-based TS→JS (strips types only)
 - `config.rs` — TOML config types, scope enum (Local/User/Project), load/save/merge logic
@@ -53,6 +53,7 @@ Claude/Codex  ──stdio──▶  CodeModeServer (server.rs)
 - **Error handling:** `anyhow::Result<()>` everywhere, `.context()` for wrapping errors. Non-fatal errors (e.g. upstream connection failure) use `tracing::warn!` and continue.
 - **Async:** tokio with `#[tokio::main]`, `Arc<Mutex<T>>` for shared mutable state.
 - **Hot-reload:** `CodeModeServer` checks config file mtimes on every request via `maybe_reload()`, reconnects all servers if changed.
+- **Startup:** `cmcp serve` creates the proxy server immediately and loads the initial upstream catalog in a background task. Until ready, `search`/`execute` return retryable initializing errors rather than an empty catalog.
 - **Environment variables:** Values prefixed with `env:` (e.g. `env:MY_TOKEN`) are resolved at runtime via `resolve_env()`.
 - **Server name sanitization:** Hyphens converted to underscores for JS identifier compatibility.
 - **Config scopes:** Local/User (`~/.config/code-mode-mcp/config.toml`) and Project (`.cmcp.toml`), merged with project overriding user.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The agent writes code to interact with tools, not JSON blobs. This means:
 
 - **99% fewer tool definitions** in context (2 vs hundreds)
 - **Hot-reload** — add servers without restarting Claude or Codex
+- **Fast startup** — `cmcp serve` exposes `search` and `execute` immediately while upstream MCP servers initialize in the background; early calls may return a retryable "still initializing" error
 - **Composable** — chain multiple tool calls in a single execution
 - **Type-safe** — auto-generated TypeScript declarations from JSON Schema
 - **Sandboxed** — code runs in a QuickJS engine with a 64 MB memory limit

--- a/README.md
+++ b/README.md
@@ -178,6 +178,21 @@ cmcp uninstall                       # Remove from both
 cmcp uninstall --target codex        # Remove from one
 ```
 
+## Agent/client routing instructions
+
+After `cmcp install`, the client sees one MCP server named `code-mode-mcp` with the `search` and `execute` tools. The repository includes a reusable skill at `skills/cmcp-mcp-router/SKILL.md` that tells agents how to route MCP work through that proxy instead of calling upstream servers directly.
+
+Use it anywhere you want the agent to understand cmcp's workflow:
+
+| Client | How to install the routing instructions |
+| --- | --- |
+| Oh My Pi | Copy `skills/cmcp-mcp-router/SKILL.md` to `~/.omp/agent/skills/cmcp-mcp-router/SKILL.md`. |
+| Claude Code | Copy the directory to `~/.claude/skills/cmcp-mcp-router/` for a personal skill, or `.claude/skills/cmcp-mcp-router/` for a project skill. |
+| OpenCode | Paste the skill's Client Instruction Block into `AGENTS.md`, or point an OpenCode agent prompt at equivalent instructions in `opencode.json`. |
+| Other MCP clients | Add the Client Instruction Block to the client's system, developer, project, or agent instructions. |
+
+The core rule for every client is: discover with `code-mode-mcp.search`, inspect the schema, then invoke with `code-mode-mcp.execute`. If direct provider MCP tools are also visible, prefer cmcp unless a server cannot be proxied, such as lifecycle-hook servers or interactive OAuth flows.
+
 ## Scopes
 
 cmcp supports the same scoping as Claude:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The agent writes code to interact with tools, not JSON blobs. This means:
 
 - **99% fewer tool definitions** in context (2 vs hundreds)
 - **Hot-reload** — add servers without restarting Claude or Codex
-- **Fast startup** — `cmcp serve` exposes `search` and `execute` immediately while upstream MCP servers initialize in the background; early calls may return a retryable "still initializing" error
+- **Fast startup** — `cmcp serve` exposes `search` and `execute` immediately while upstream MCP servers connect concurrently in the background; tools become available as each server connects
 - **Composable** — chain multiple tool calls in a single execution
 - **Type-safe** — auto-generated TypeScript declarations from JSON Schema
 - **Sandboxed** — code runs in a QuickJS engine with a 64 MB memory limit

--- a/README.md
+++ b/README.md
@@ -178,20 +178,21 @@ cmcp uninstall                       # Remove from both
 cmcp uninstall --target codex        # Remove from one
 ```
 
-## Agent/client routing instructions
+## Agent skill
 
-After `cmcp install`, the client sees one MCP server named `code-mode-mcp` with the `search` and `execute` tools. The repository includes a reusable skill at `skills/cmcp-mcp-router/SKILL.md` that tells agents how to route MCP work through that proxy instead of calling upstream servers directly.
+After `cmcp install`, the client sees one MCP server named `code-mode-mcp` with the `search` and `execute` tools. The repository includes an [Agent Skills](https://agentskills.io) skill at `skills/cmcp-mcp-router/SKILL.md` that tells agents to route MCP work through the proxy instead of calling upstream servers directly.
 
-Use it anywhere you want the agent to understand cmcp's workflow:
+Any Agent Skills–compatible client will discover the skill automatically when placed in a standard skill directory. Install it by copying or symlinking the `cmcp-mcp-router/` directory:
 
-| Client | How to install the routing instructions |
+| Scope | Location |
 | --- | --- |
-| Oh My Pi | Copy `skills/cmcp-mcp-router/SKILL.md` to `~/.omp/agent/skills/cmcp-mcp-router/SKILL.md`. |
-| Claude Code | Copy the directory to `~/.claude/skills/cmcp-mcp-router/` for a personal skill, or `.claude/skills/cmcp-mcp-router/` for a project skill. |
-| OpenCode | Paste the skill's Client Instruction Block into `AGENTS.md`, or point an OpenCode agent prompt at equivalent instructions in `opencode.json`. |
-| Other MCP clients | Add the Client Instruction Block to the client's system, developer, project, or agent instructions. |
+| Project (OpenCode) | `.opencode/skills/cmcp-mcp-router/` |
+| Project (Claude Code) | `.claude/skills/cmcp-mcp-router/` |
+| Global (OpenCode) | `~/.config/opencode/skills/cmcp-mcp-router/` |
+| Global (Claude Code) | `~/.claude/skills/cmcp-mcp-router/` |
+| Global (any compatible client) | `~/.agents/skills/cmcp-mcp-router/` |
 
-The core rule for every client is: discover with `code-mode-mcp.search`, inspect the schema, then invoke with `code-mode-mcp.execute`. If direct provider MCP tools are also visible, prefer cmcp unless a server cannot be proxied, such as lifecycle-hook servers or interactive OAuth flows.
+OpenCode also discovers skills from `.agents/skills/` at the project root, so the included `skills/` directory works if symlinked or copied there. For other clients, add the skill directory wherever the client looks for Agent Skills.
 
 ## Scopes
 

--- a/skills/cmcp-mcp-router/SKILL.md
+++ b/skills/cmcp-mcp-router/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: cmcp-mcp-router
+description: Route all MCP work through the code-mode-mcp proxy. Discover with search first, then invoke with execute; do not call upstream MCP servers directly.
+---
+
+# Route MCP through cmcp
+
+Use this skill in any AI client that has `cmcp` installed as an MCP server. The goal is not to teach the project; the goal is to make the client use the `code-mode-mcp` proxy correctly.
+
+## When to use
+
+Use this skill whenever a task requires MCP tools and the client has access to the `code-mode-mcp` server.
+
+`cmcp` exposes a single gateway server with two tools:
+- `search`: inspect the available upstream MCP tools and schemas by running TypeScript against the tool catalog.
+- `execute`: call upstream MCP tools by running typed async TypeScript.
+
+## Non-negotiable rules
+
+1. Always run `search` before calling an MCP tool through `execute`.
+2. Always call upstream MCP tools through `execute` when `code-mode-mcp` is available.
+3. Do not call provider-specific MCP servers directly unless `code-mode-mcp` is unavailable or the server is explicitly listed as an exception.
+4. Do not guess tool names, schema fields, or server globals. Inspect metadata first with `search`.
+5. Return only the fields needed for the task to avoid context bloat.
+6. Prefer one `execute` call for a coherent tool workflow; use `Promise.all` only for independent calls.
+
+## Client tool naming
+
+Different clients display the same cmcp tools with different names. Treat these as equivalent:
+
+| Client | Discovery tool | Invocation tool |
+| --- | --- | --- |
+| Oh My Pi | `mcp_code_mode_mcp_search` | `mcp_code_mode_mcp_execute` |
+| Claude Code / Claude Desktop | `code-mode-mcp.search` or `search` under `code-mode-mcp` | `code-mode-mcp.execute` or `execute` under `code-mode-mcp` |
+| OpenCode | `search` under the configured `code-mode-mcp` MCP server | `execute` under the configured `code-mode-mcp` MCP server |
+| Other MCP clients | the cmcp server's `search` tool | the cmcp server's `execute` tool |
+
+If both cmcp and a direct upstream provider tool are visible, use cmcp unless the direct server is in the exceptions section.
+
+## Standard workflow
+
+### 1. Discover with `search`
+
+Find candidate tools:
+
+```typescript
+return tools
+  .filter(t =>
+    t.name.includes("issue") ||
+    t.description.toLowerCase().includes("issue") ||
+    t.server.toLowerCase().includes("github")
+  )
+  .map(t => ({
+    server: t.server,
+    name: t.name,
+    description: t.description,
+  }));
+```
+
+Inspect a schema before invoking:
+
+```typescript
+const tool = tools.find(t => t.server === "github" && t.name === "create_issue");
+return tool
+  ? { server: tool.server, name: tool.name, input_schema: tool.input_schema }
+  : null;
+```
+
+### 2. Invoke with `execute`
+
+Single tool call:
+
+```typescript
+const issue = await github.create_issue({
+  owner: "acme",
+  repo: "platform",
+  title: "Bug: login fails",
+  body: "Steps to reproduce...",
+});
+
+return { number: issue.number, url: issue.html_url };
+```
+
+Chained calls in one workflow:
+
+```typescript
+const open = await github.list_issues({
+  owner: "acme",
+  repo: "platform",
+  state: "open",
+});
+
+await slack.post_message({
+  channel: "#eng-alerts",
+  text: `Open issues: ${open.length}`,
+});
+
+return { open_count: open.length, notified: true };
+```
+
+Parallel independent calls:
+
+```typescript
+const [issues, deploys] = await Promise.all([
+  github.list_issues({ owner: "acme", repo: "platform", state: "open" }),
+  vercel.list_deployments({ project_id: "prj_123" }),
+]);
+
+return { issue_count: issues.length, deployment_count: deploys.length };
+```
+
+## Server global naming
+
+Server names are sanitized into TypeScript globals inside `execute`:
+
+- `my-server` becomes `my_server`
+- `github-enterprise` becomes `github_enterprise`
+
+Use `search` to confirm the server name, then use the sanitized identifier in `execute`.
+
+## Missing tool or server
+
+If `search` does not show the server or tool you need:
+
+1. Check the cmcp server list outside the client:
+
+   ```bash
+   cmcp list --short
+   ```
+
+2. Add the missing upstream server to cmcp:
+
+   ```bash
+   # HTTP MCP server
+   cmcp add canva https://mcp.canva.com/mcp
+
+   # stdio MCP server
+   cmcp add --transport stdio github -- npx -y @modelcontextprotocol/server-github
+   ```
+
+3. If the client does not show the cmcp proxy itself, install or reinstall cmcp into the client:
+
+   ```bash
+   cmcp install
+   ```
+
+4. Retry `search`. cmcp hot-reloads config changes, so newly added servers should appear on later calls without restarting most clients.
+
+## Installing these instructions into clients
+
+Use the most native instruction mechanism each client supports:
+
+- Oh My Pi: install this file at `~/.omp/agent/skills/cmcp-mcp-router/SKILL.md` or add this project skill directory to the OMP skill source.
+- Claude Code: copy this directory to `~/.claude/skills/cmcp-mcp-router/` for a personal skill, or `.claude/skills/cmcp-mcp-router/` for a project skill.
+- OpenCode: paste the Client Instruction Block below into `AGENTS.md`, or reference a prompt file containing it from an OpenCode agent in `opencode.json`.
+- Other clients: add the Client Instruction Block to the client's system, developer, project, or agent instructions.
+
+### Client Instruction Block
+
+```text
+When MCP tools are needed and the `code-mode-mcp` server is available, route all MCP work through cmcp. First use the cmcp `search` tool to discover the relevant upstream tool and inspect its schema. Then use the cmcp `execute` tool to call the upstream tool with typed TypeScript. Do not call provider-specific MCP servers directly unless cmcp is unavailable or the server cannot be proxied. Do not guess tool names, parameter names, or schemas; inspect them first. Return only the fields needed for the task.
+```
+
+## Exceptions
+
+Some servers may need direct client registration instead of proxying through cmcp:
+
+- Hook- or lifecycle-dependent servers that require tight integration with the host client.
+- Interactive OAuth/browser callback flows that the proxy cannot complete.
+- Client-local tools that are not MCP servers.
+
+When an exception is required, state the reason and keep the boundary explicit: use cmcp for all proxy-compatible MCP servers, and call the direct tool only for the exception.
+
+## Quick checklist
+
+- Discover with `search`.
+- Confirm the schema.
+- Invoke with `execute`.
+- Return minimal data.
+- If missing, run `cmcp list --short`, add the server with `cmcp add`, then retry `search`.

--- a/skills/cmcp-mcp-router/SKILL.md
+++ b/skills/cmcp-mcp-router/SKILL.md
@@ -1,180 +1,24 @@
 ---
 name: cmcp-mcp-router
-description: Route all MCP work through the code-mode-mcp proxy. Discover with search first, then invoke with execute; do not call upstream MCP servers directly.
+description: "Route all MCP tool calls through the code-mode-mcp proxy. Use when MCP tools are needed and the code-mode-mcp server is available. Triggers on any task requiring upstream MCP tool access."
+compatibility: Requires cmcp installed as an MCP server
 ---
 
 # Route MCP through cmcp
 
-Use this skill in any AI client that has `cmcp` installed as an MCP server. The goal is not to teach the project; the goal is to make the client use the `code-mode-mcp` proxy correctly.
+When MCP tools are needed and the `code-mode-mcp` server is available, route all MCP work through it.
 
-## When to use
+## Rules
 
-Use this skill whenever a task requires MCP tools and the client has access to the `code-mode-mcp` server.
-
-`cmcp` exposes a single gateway server with two tools:
-- `search`: inspect the available upstream MCP tools and schemas by running TypeScript against the tool catalog.
-- `execute`: call upstream MCP tools by running typed async TypeScript.
-
-## Non-negotiable rules
-
-1. Always run `search` before calling an MCP tool through `execute`.
-2. Always call upstream MCP tools through `execute` when `code-mode-mcp` is available.
-3. Do not call provider-specific MCP servers directly unless `code-mode-mcp` is unavailable or the server is explicitly listed as an exception.
-4. Do not guess tool names, schema fields, or server globals. Inspect metadata first with `search`.
-5. Return only the fields needed for the task to avoid context bloat.
-6. Prefer one `execute` call for a coherent tool workflow; use `Promise.all` only for independent calls.
-
-## Client tool naming
-
-Different clients display the same cmcp tools with different names. Treat these as equivalent:
-
-| Client | Discovery tool | Invocation tool |
-| --- | --- | --- |
-| Oh My Pi | `mcp_code_mode_mcp_search` | `mcp_code_mode_mcp_execute` |
-| Claude Code / Claude Desktop | `code-mode-mcp.search` or `search` under `code-mode-mcp` | `code-mode-mcp.execute` or `execute` under `code-mode-mcp` |
-| OpenCode | `search` under the configured `code-mode-mcp` MCP server | `execute` under the configured `code-mode-mcp` MCP server |
-| Other MCP clients | the cmcp server's `search` tool | the cmcp server's `execute` tool |
-
-If both cmcp and a direct upstream provider tool are visible, use cmcp unless the direct server is in the exceptions section.
-
-## Standard workflow
-
-### 1. Discover with `search`
-
-Find candidate tools:
-
-```typescript
-return tools
-  .filter(t =>
-    t.name.includes("issue") ||
-    t.description.toLowerCase().includes("issue") ||
-    t.server.toLowerCase().includes("github")
-  )
-  .map(t => ({
-    server: t.server,
-    name: t.name,
-    description: t.description,
-  }));
-```
-
-Inspect a schema before invoking:
-
-```typescript
-const tool = tools.find(t => t.server === "github" && t.name === "create_issue");
-return tool
-  ? { server: tool.server, name: tool.name, input_schema: tool.input_schema }
-  : null;
-```
-
-### 2. Invoke with `execute`
-
-Single tool call:
-
-```typescript
-const issue = await github.create_issue({
-  owner: "acme",
-  repo: "platform",
-  title: "Bug: login fails",
-  body: "Steps to reproduce...",
-});
-
-return { number: issue.number, url: issue.html_url };
-```
-
-Chained calls in one workflow:
-
-```typescript
-const open = await github.list_issues({
-  owner: "acme",
-  repo: "platform",
-  state: "open",
-});
-
-await slack.post_message({
-  channel: "#eng-alerts",
-  text: `Open issues: ${open.length}`,
-});
-
-return { open_count: open.length, notified: true };
-```
-
-Parallel independent calls:
-
-```typescript
-const [issues, deploys] = await Promise.all([
-  github.list_issues({ owner: "acme", repo: "platform", state: "open" }),
-  vercel.list_deployments({ project_id: "prj_123" }),
-]);
-
-return { issue_count: issues.length, deployment_count: deploys.length };
-```
+1. Use `search` to discover tools and inspect schemas before calling anything.
+2. Use `execute` to invoke upstream MCP tools. Do not call provider-specific MCP servers directly.
+3. Do not guess tool names or parameters. Inspect with `search` first.
+4. Return only the fields you need. Use the `max_length` parameter on `search` and `execute` (default 40k chars) to limit response size when possible.
 
 ## Server global naming
 
-Server names are sanitized into TypeScript globals inside `execute`:
+Hyphens in server names become underscores in `execute` code: `my-server` → `my_server`.
 
-- `my-server` becomes `my_server`
-- `github-enterprise` becomes `github_enterprise`
+## Initialization
 
-Use `search` to confirm the server name, then use the sanitized identifier in `execute`.
-
-## Missing tool or server
-
-If `search` does not show the server or tool you need:
-
-1. Check the cmcp server list outside the client:
-
-   ```bash
-   cmcp list --short
-   ```
-
-2. Add the missing upstream server to cmcp:
-
-   ```bash
-   # HTTP MCP server
-   cmcp add canva https://mcp.canva.com/mcp
-
-   # stdio MCP server
-   cmcp add --transport stdio github -- npx -y @modelcontextprotocol/server-github
-   ```
-
-3. If the client does not show the cmcp proxy itself, install or reinstall cmcp into the client:
-
-   ```bash
-   cmcp install
-   ```
-
-4. Retry `search`. cmcp hot-reloads config changes, so newly added servers should appear on later calls without restarting most clients.
-
-## Installing these instructions into clients
-
-Use the most native instruction mechanism each client supports:
-
-- Oh My Pi: install this file at `~/.omp/agent/skills/cmcp-mcp-router/SKILL.md` or add this project skill directory to the OMP skill source.
-- Claude Code: copy this directory to `~/.claude/skills/cmcp-mcp-router/` for a personal skill, or `.claude/skills/cmcp-mcp-router/` for a project skill.
-- OpenCode: paste the Client Instruction Block below into `AGENTS.md`, or reference a prompt file containing it from an OpenCode agent in `opencode.json`.
-- Other clients: add the Client Instruction Block to the client's system, developer, project, or agent instructions.
-
-### Client Instruction Block
-
-```text
-When MCP tools are needed and the `code-mode-mcp` server is available, route all MCP work through cmcp. First use the cmcp `search` tool to discover the relevant upstream tool and inspect its schema. Then use the cmcp `execute` tool to call the upstream tool with typed TypeScript. Do not call provider-specific MCP servers directly unless cmcp is unavailable or the server cannot be proxied. Do not guess tool names, parameter names, or schemas; inspect them first. Return only the fields needed for the task.
-```
-
-## Exceptions
-
-Some servers may need direct client registration instead of proxying through cmcp:
-
-- Hook- or lifecycle-dependent servers that require tight integration with the host client.
-- Interactive OAuth/browser callback flows that the proxy cannot complete.
-- Client-local tools that are not MCP servers.
-
-When an exception is required, state the reason and keep the boundary explicit: use cmcp for all proxy-compatible MCP servers, and call the direct tool only for the exception.
-
-## Quick checklist
-
-- Discover with `search`.
-- Confirm the schema.
-- Invoke with `execute`.
-- Return minimal data.
-- If missing, run `cmcp list --short`, add the server with `cmcp add`, then retry `search`.
+If `search` returns an initializing error, upstream servers are still connecting. Retry after a moment — cmcp hot-reloads and does not need a restart.

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig
 use rmcp::transport::ConfigureCommandExt;
 use rmcp::{RoleClient, ServiceExt};
 use tokio::process::Command;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use tracing::info;
 
 use crate::catalog::Catalog;
@@ -21,15 +21,28 @@ struct UpstreamServer {
 
 /// Manages connections to all upstream MCP servers.
 pub struct ClientPool {
-    servers: HashMap<String, Mutex<UpstreamServer>>,
+    servers: RwLock<HashMap<String, Mutex<UpstreamServer>>>,
+}
+
+impl Default for ClientPool {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ClientPool {
+    /// Create an empty pool with no connected servers.
+    pub fn new() -> Self {
+        Self {
+            servers: RwLock::new(HashMap::new()),
+        }
+    }
+
     /// Connect to all configured servers and build the tool catalog.
     pub async fn connect(
         configs: HashMap<String, ServerConfig>,
     ) -> Result<(Self, Catalog)> {
-        let mut servers = HashMap::new();
+        let pool = Self::new();
         let mut catalog = Catalog::new();
 
         for (name, config) in configs {
@@ -37,10 +50,7 @@ impl ClientPool {
                 Ok((service, tools)) => {
                     info!(server = %name, tool_count = tools.len(), "connected");
                     catalog.add_server_tools(&name, tools);
-                    servers.insert(
-                        name,
-                        Mutex::new(UpstreamServer { service, config }),
-                    );
+                    pool.add_server(name, service, config).await;
                 }
                 Err(e) => {
                     tracing::warn!(server = %name, error = %e, "failed to connect, skipping");
@@ -48,7 +58,17 @@ impl ClientPool {
             }
         }
 
-        Ok((Self { servers }, catalog))
+        Ok((pool, catalog))
+    }
+
+    /// Add a connected server to the pool.
+    pub async fn add_server(
+        &self,
+        name: String,
+        service: RunningService<RoleClient, ()>,
+        config: ServerConfig,
+    ) {
+        self.servers.write().await.insert(name, Mutex::new(UpstreamServer { service, config }));
     }
 
     /// Build the transport config for HTTP/SSE servers.
@@ -83,7 +103,7 @@ impl ClientPool {
         config
     }
 
-    async fn connect_one(
+    pub async fn connect_one(
         name: &str,
         config: &ServerConfig,
     ) -> Result<(RunningService<RoleClient, ()>, Vec<rmcp::model::Tool>)> {
@@ -136,8 +156,8 @@ impl ClientPool {
         tool_name: &str,
         arguments: serde_json::Value,
     ) -> Result<CallToolResult> {
-        let upstream_mutex = self
-            .servers
+        let servers = self.servers.read().await;
+        let upstream_mutex = servers
             .get(server_name)
             .with_context(|| format!("no server named '{server_name}'"))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,9 @@ pub mod transpile;
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use tokio::sync::Mutex;
 
 use catalog::Catalog;
@@ -48,10 +49,18 @@ struct ProxyState {
     _pool: Arc<ClientPool>,
 }
 
+enum EngineState {
+    Initializing { server_count: usize },
+    Ready(ProxyState),
+    Failed { server_count: usize, error: String },
+}
+
 /// The core proxy engine that manages upstream MCP server connections
 /// and executes agent-written TypeScript code against them.
+#[derive(Clone)]
 pub struct ProxyEngine {
-    state: Mutex<ProxyState>,
+    state: Arc<Mutex<EngineState>>,
+    generation: Arc<AtomicU64>,
 }
 
 impl ProxyEngine {
@@ -61,18 +70,60 @@ impl ProxyEngine {
     pub async fn from_configs(servers: HashMap<String, ServerConfig>) -> Result<Self> {
         let state = ProxyState::new(servers).await?;
         Ok(Self {
-            state: Mutex::new(state),
+            state: Arc::new(Mutex::new(EngineState::Ready(state))),
+            generation: Arc::new(AtomicU64::new(0)),
         })
+    }
+
+    /// Create a ProxyEngine in the Initializing state.
+    pub fn starting(server_count: usize) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(EngineState::Initializing { server_count })),
+            generation: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Start loading upstream servers in a background task.
+    pub fn start_background_load(self: &Arc<Self>, servers: HashMap<String, ServerConfig>) {
+        let server_count = servers.len();
+        let load_generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        let engine = self.clone();
+        tokio::spawn(async move {
+            match ProxyState::new(servers).await {
+                Ok(new_state) => {
+                    let mut state = engine.state.lock().await;
+                    if engine.generation.load(Ordering::SeqCst) == load_generation {
+                        *state = EngineState::Ready(new_state);
+                    }
+                }
+                Err(e) => {
+                    let mut state = engine.state.lock().await;
+                    if engine.generation.load(Ordering::SeqCst) == load_generation {
+                        *state = EngineState::Failed { server_count, error: e.to_string() };
+                    }
+                }
+            }
+        });
     }
 
     /// Execute a search query — agent TypeScript code that filters the tool catalog.
     pub async fn search(&self, code: &str, max_length: Option<usize>) -> Result<serde_json::Value> {
         let max_len = max_length.unwrap_or(DEFAULT_MAX_LENGTH);
         let state = self.state.lock().await;
-        let result = state.sandbox.search(code).await?;
-        let text = serde_json::to_string_pretty(&result)?;
-        let truncated = truncate_response(text, max_len);
-        serde_json::from_str(&truncated).or(Ok(serde_json::Value::String(truncated)))
+        match &*state {
+            EngineState::Ready(proxy_state) => {
+                let result = proxy_state.sandbox.search(code).await?;
+                let text = serde_json::to_string_pretty(&result)?;
+                let truncated = truncate_response(text, max_len);
+                serde_json::from_str(&truncated).or(Ok(serde_json::Value::String(truncated)))
+            }
+            EngineState::Initializing { server_count } => {
+                Err(anyhow!("cmcp is still initializing the upstream tool catalog for {server_count} configured MCP server(s); try again shortly"))
+            }
+            EngineState::Failed { server_count, error } => {
+                Err(anyhow!("cmcp failed to initialize {server_count} configured MCP server(s): {error}"))
+            }
+        }
     }
 
     /// Execute tool-calling code — agent TypeScript that calls tools across servers.
@@ -82,53 +133,82 @@ impl ProxyEngine {
     pub async fn execute(&self, code: &str, max_length: Option<usize>) -> Result<ExecuteResult> {
         let max_len = max_length.unwrap_or(DEFAULT_MAX_LENGTH);
         let state = self.state.lock().await;
-        let mut result = state.sandbox.execute(code).await?;
+        match &*state {
+            EngineState::Ready(proxy_state) => {
+                let mut result = proxy_state.sandbox.execute(code).await?;
 
-        // Extract images before truncation so base64 data isn't corrupted.
-        let images = extract_images(&mut result);
+                // Extract images before truncation so base64 data isn't corrupted.
+                let images = extract_images(&mut result);
 
-        let text = serde_json::to_string_pretty(&result)?;
-        let truncated = truncate_response(text, max_len);
+                let text = serde_json::to_string_pretty(&result)?;
+                let truncated = truncate_response(text, max_len);
 
-        Ok(ExecuteResult {
-            text: truncated,
-            images,
-        })
+                Ok(ExecuteResult {
+                    text: truncated,
+                    images,
+                })
+            }
+            EngineState::Initializing { server_count } => {
+                Err(anyhow!("cmcp is still initializing the upstream tool catalog for {server_count} configured MCP server(s); try again shortly"))
+            }
+            EngineState::Failed { server_count, error } => {
+                Err(anyhow!("cmcp failed to initialize {server_count} configured MCP server(s): {error}"))
+            }
+        }
     }
 
     /// Reload the proxy with a new set of server configs.
     /// Reconnects to all servers and rebuilds the catalog and sandbox.
     pub async fn reload(&self, servers: HashMap<String, ServerConfig>) -> Result<()> {
+        let reload_generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
         let new_state = ProxyState::new(servers).await?;
         let mut state = self.state.lock().await;
-        *state = new_state;
+        if self.generation.load(Ordering::SeqCst) == reload_generation {
+            *state = EngineState::Ready(new_state);
+        }
         Ok(())
     }
 
     /// Get a summary of the connected servers and tools.
     pub async fn summary(&self) -> String {
         let state = self.state.lock().await;
-        state.catalog.summary()
+        match &*state {
+            EngineState::Ready(proxy_state) => proxy_state.catalog.summary(),
+            EngineState::Initializing { server_count } => {
+                format!("cmcp is initializing the upstream tool catalog for {server_count} configured MCP server(s)")
+            }
+            EngineState::Failed { server_count, error } => {
+                format!("cmcp initialization failed for {server_count} configured MCP server(s): {error}")
+            }
+        }
     }
 
     /// Get the number of tools in the catalog.
     pub async fn tool_count(&self) -> usize {
         let state = self.state.lock().await;
-        state.catalog.entries().len()
+        match &*state {
+            EngineState::Ready(proxy_state) => proxy_state.catalog.entries().len(),
+            _ => 0,
+        }
     }
 
     /// Get tool names grouped by server, sorted alphabetically.
     pub async fn catalog_entries_by_server(&self) -> std::collections::BTreeMap<String, Vec<String>> {
         let state = self.state.lock().await;
-        let mut servers: std::collections::BTreeMap<String, Vec<String>> =
-            std::collections::BTreeMap::new();
-        for entry in state.catalog.entries() {
-            servers
-                .entry(entry.server.clone())
-                .or_default()
-                .push(entry.name.clone());
+        match &*state {
+            EngineState::Ready(proxy_state) => {
+                let mut servers: std::collections::BTreeMap<String, Vec<String>> =
+                    std::collections::BTreeMap::new();
+                for entry in proxy_state.catalog.entries() {
+                    servers
+                        .entry(entry.server.clone())
+                        .or_default()
+                        .push(entry.name.clone());
+                }
+                servers
+            }
+            _ => std::collections::BTreeMap::new(),
         }
-        servers
     }
 }
 
@@ -208,5 +288,66 @@ fn extract_images_recursive(value: &mut serde_json::Value, images: &mut Vec<Imag
             }
         }
         _ => {}
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::time::{sleep, timeout};
+
+    #[tokio::test]
+    async fn starting_search_returns_retryable_initializing_error() {
+        let engine = ProxyEngine::starting(3);
+
+        let error = engine
+            .search("return tools;", None)
+            .await
+            .expect_err("search should fail while the engine is initializing");
+        let message = error.to_string();
+
+        assert!(message.contains("still initializing"));
+        assert!(message.contains("3 configured MCP server(s)"));
+    }
+
+    #[tokio::test]
+    async fn starting_execute_returns_retryable_initializing_error() {
+        let engine = ProxyEngine::starting(2);
+
+        let error = engine
+            .execute("return null;", None)
+            .await
+            .expect_err("execute should fail while the engine is initializing");
+        let message = error.to_string();
+
+        assert!(message.contains("still initializing"));
+        assert!(message.contains("2 configured MCP server(s)"));
+    }
+
+    #[tokio::test]
+    async fn background_load_empty_config_becomes_ready() {
+        let engine = Arc::new(ProxyEngine::starting(0));
+        engine.start_background_load(HashMap::new());
+
+        let result = timeout(Duration::from_secs(2), async {
+            loop {
+                match engine.search("return tools;", None).await {
+                    Ok(value) => break value,
+                    Err(error) if error.to_string().contains("still initializing") => {
+                        sleep(Duration::from_millis(10)).await;
+                    }
+                    Err(error) => panic!("unexpected search error: {error}"),
+                }
+            }
+        })
+        .await
+        .expect("background load did not complete");
+
+        assert_eq!(result, json!([]));
+        assert_eq!(engine.tool_count().await, 0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,11 @@ pub mod transpile;
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
-use anyhow::{Result, anyhow};
-use tokio::sync::Mutex;
+use anyhow::Result;
+use tokio::sync::{Mutex, RwLock};
+use tracing::info;
 
 use catalog::Catalog;
 use client::ClientPool;
@@ -40,27 +41,26 @@ pub struct ExecuteResult {
     pub images: Vec<ImageData>,
 }
 
-/// Mutable state that gets replaced atomically on reload.
-/// `pool` is kept alive here — the Sandbox holds its own Arc<ClientPool>
-/// reference for tool calls, but we retain ownership for lifecycle management.
+/// Mutable state that is updated incrementally as servers connect.
 struct ProxyState {
     sandbox: Sandbox,
-    catalog: Arc<Catalog>,
+    catalog: Arc<RwLock<Catalog>>,
     _pool: Arc<ClientPool>,
-}
-
-enum EngineState {
-    Initializing { server_count: usize },
-    Ready(ProxyState),
-    Failed { server_count: usize, error: String },
 }
 
 /// The core proxy engine that manages upstream MCP server connections
 /// and executes agent-written TypeScript code against them.
+///
+/// Servers are loaded incrementally: `search`/`execute` return results
+/// immediately with whatever servers are ready, while remaining servers
+/// continue connecting in the background.
 #[derive(Clone)]
 pub struct ProxyEngine {
-    state: Arc<Mutex<EngineState>>,
+    state: Arc<Mutex<ProxyState>>,
     generation: Arc<AtomicU64>,
+    pending: Arc<AtomicUsize>,
+    total_servers: Arc<AtomicUsize>,
+    failed: Arc<Mutex<Vec<(String, String)>>>,
 }
 
 impl ProxyEngine {
@@ -70,60 +70,102 @@ impl ProxyEngine {
     pub async fn from_configs(servers: HashMap<String, ServerConfig>) -> Result<Self> {
         let state = ProxyState::new(servers).await?;
         Ok(Self {
-            state: Arc::new(Mutex::new(EngineState::Ready(state))),
+            state: Arc::new(Mutex::new(state)),
             generation: Arc::new(AtomicU64::new(0)),
+            pending: Arc::new(AtomicUsize::new(0)),
+            total_servers: Arc::new(AtomicUsize::new(0)),
+            failed: Arc::new(Mutex::new(Vec::new())),
         })
     }
 
-    /// Create a ProxyEngine in the Initializing state.
-    pub fn starting(server_count: usize) -> Self {
+    /// Create a ProxyEngine with an empty catalog, ready for incremental loading.
+    /// `total_servers` is the number of servers that will be loaded in the background.
+    pub async fn starting(total_servers: usize) -> Self {
+        let pool = Arc::new(ClientPool::new());
+        let catalog = Arc::new(RwLock::new(Catalog::new()));
+        let sandbox = Sandbox::new(pool.clone(), catalog.clone()).await
+            .expect("failed to create sandbox");
+
+        let state = ProxyState {
+            sandbox,
+            catalog,
+            _pool: pool,
+        };
+
         Self {
-            state: Arc::new(Mutex::new(EngineState::Initializing { server_count })),
+            state: Arc::new(Mutex::new(state)),
             generation: Arc::new(AtomicU64::new(0)),
+            pending: Arc::new(AtomicUsize::new(total_servers)),
+            total_servers: Arc::new(AtomicUsize::new(total_servers)),
+            failed: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
-    /// Start loading upstream servers in a background task.
+    /// Start loading upstream servers in background tasks (one per server).
+    /// Each server connects concurrently; search/execute become usable as
+    /// each one completes.
     pub fn start_background_load(self: &Arc<Self>, servers: HashMap<String, ServerConfig>) {
-        let server_count = servers.len();
         let load_generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
-        let engine = self.clone();
-        tokio::spawn(async move {
-            match ProxyState::new(servers).await {
-                Ok(new_state) => {
-                    let mut state = engine.state.lock().await;
-                    if engine.generation.load(Ordering::SeqCst) == load_generation {
-                        *state = EngineState::Ready(new_state);
+        self.pending.store(servers.len(), Ordering::SeqCst);
+
+        for (name, config) in servers {
+            let engine = self.clone();
+            let expected_gen = load_generation;
+            tokio::spawn(async move {
+                let result = ClientPool::connect_one(&name, &config).await;
+                if engine.generation.load(Ordering::SeqCst) != expected_gen {
+                    return;
+                }
+                match result {
+                    Ok((service, tools)) => {
+                        info!(server = %name, tool_count = tools.len(), "connected");
+                        let state = engine.state.lock().await;
+                        state._pool.add_server(name.clone(), service, config).await;
+                        state.catalog.write().await.add_server_tools(&name, tools);
+                    }
+                    Err(e) => {
+                        tracing::warn!(server = %name, error = %e, "failed to connect, skipping");
+                        engine.failed.lock().await.push((name, e.to_string()));
                     }
                 }
-                Err(e) => {
-                    let mut state = engine.state.lock().await;
-                    if engine.generation.load(Ordering::SeqCst) == load_generation {
-                        *state = EngineState::Failed { server_count, error: e.to_string() };
-                    }
-                }
+                engine.pending.fetch_sub(1, Ordering::SeqCst);
+            });
+        }
+    }
+
+    /// Build a status suffix describing pending/failed servers.
+    async fn status_suffix(&self) -> String {
+        let pending = self.pending.load(Ordering::SeqCst);
+        let total = self.total_servers.load(Ordering::SeqCst);
+        if pending > 0 {
+            let ready = total.saturating_sub(pending);
+            format!("\n\n[{ready} of {total} server(s) connected; {pending} still loading — retry for more tools]")
+        } else {
+            let failed = self.failed.lock().await;
+            if failed.is_empty() {
+                String::new()
+            } else {
+                let details: Vec<String> = failed
+                    .iter()
+                    .map(|(name, err)| format!("{name}: {err}"))
+                    .collect();
+                format!("\n\n[failed servers: {}]", details.join(", "))
             }
-        });
+        }
     }
 
     /// Execute a search query — agent TypeScript code that filters the tool catalog.
     pub async fn search(&self, code: &str, max_length: Option<usize>) -> Result<serde_json::Value> {
         let max_len = max_length.unwrap_or(DEFAULT_MAX_LENGTH);
         let state = self.state.lock().await;
-        match &*state {
-            EngineState::Ready(proxy_state) => {
-                let result = proxy_state.sandbox.search(code).await?;
-                let text = serde_json::to_string_pretty(&result)?;
-                let truncated = truncate_response(text, max_len);
-                serde_json::from_str(&truncated).or(Ok(serde_json::Value::String(truncated)))
-            }
-            EngineState::Initializing { server_count } => {
-                Err(anyhow!("cmcp is still initializing the upstream tool catalog for {server_count} configured MCP server(s); try again shortly"))
-            }
-            EngineState::Failed { server_count, error } => {
-                Err(anyhow!("cmcp failed to initialize {server_count} configured MCP server(s): {error}"))
-            }
+        let result = state.sandbox.search(code).await?;
+        let mut text = serde_json::to_string_pretty(&result)?;
+        let suffix = self.status_suffix().await;
+        if !suffix.is_empty() {
+            text.push_str(&suffix);
         }
+        let truncated = truncate_response(text, max_len);
+        serde_json::from_str(&truncated).or(Ok(serde_json::Value::String(truncated)))
     }
 
     /// Execute tool-calling code — agent TypeScript that calls tools across servers.
@@ -133,89 +175,117 @@ impl ProxyEngine {
     pub async fn execute(&self, code: &str, max_length: Option<usize>) -> Result<ExecuteResult> {
         let max_len = max_length.unwrap_or(DEFAULT_MAX_LENGTH);
         let state = self.state.lock().await;
-        match &*state {
-            EngineState::Ready(proxy_state) => {
-                let mut result = proxy_state.sandbox.execute(code).await?;
+        let mut result = state.sandbox.execute(code).await?;
 
-                // Extract images before truncation so base64 data isn't corrupted.
-                let images = extract_images(&mut result);
+        let images = extract_images(&mut result);
 
-                let text = serde_json::to_string_pretty(&result)?;
-                let truncated = truncate_response(text, max_len);
-
-                Ok(ExecuteResult {
-                    text: truncated,
-                    images,
-                })
-            }
-            EngineState::Initializing { server_count } => {
-                Err(anyhow!("cmcp is still initializing the upstream tool catalog for {server_count} configured MCP server(s); try again shortly"))
-            }
-            EngineState::Failed { server_count, error } => {
-                Err(anyhow!("cmcp failed to initialize {server_count} configured MCP server(s): {error}"))
-            }
+        let mut text = serde_json::to_string_pretty(&result)?;
+        let suffix = self.status_suffix().await;
+        if !suffix.is_empty() {
+            text.push_str(&suffix);
         }
+        let truncated = truncate_response(text, max_len);
+
+        Ok(ExecuteResult {
+            text: truncated,
+            images,
+        })
     }
 
     /// Reload the proxy with a new set of server configs.
-    /// Reconnects to all servers and rebuilds the catalog and sandbox.
+    /// Resets state and spawns concurrent background load for each server.
     pub async fn reload(&self, servers: HashMap<String, ServerConfig>) -> Result<()> {
         let reload_generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
-        let new_state = ProxyState::new(servers).await?;
-        let mut state = self.state.lock().await;
-        if self.generation.load(Ordering::SeqCst) == reload_generation {
-            *state = EngineState::Ready(new_state);
+        let total = servers.len();
+
+        let pool = Arc::new(ClientPool::new());
+        let catalog = Arc::new(RwLock::new(Catalog::new()));
+        let sandbox = Sandbox::new(pool.clone(), catalog.clone()).await?;
+
+        {
+            let mut state = self.state.lock().await;
+            if self.generation.load(Ordering::SeqCst) == reload_generation {
+                *state = ProxyState {
+                    sandbox,
+                    catalog,
+                    _pool: pool,
+                };
+            }
         }
+
+        self.total_servers.store(total, Ordering::SeqCst);
+        self.pending.store(total, Ordering::SeqCst);
+        self.failed.lock().await.clear();
+
+        let engine: Arc<Self> = Arc::new(self.clone());
+        for (name, config) in servers {
+            let eng = engine.clone();
+            let expected_gen = reload_generation;
+            tokio::spawn(async move {
+                let result = ClientPool::connect_one(&name, &config).await;
+                if eng.generation.load(Ordering::SeqCst) != expected_gen {
+                    return;
+                }
+                match result {
+                    Ok((service, tools)) => {
+                        info!(server = %name, tool_count = tools.len(), "reconnected");
+                        let state = eng.state.lock().await;
+                        state._pool.add_server(name.clone(), service, config).await;
+                        state.catalog.write().await.add_server_tools(&name, tools);
+                    }
+                    Err(e) => {
+                        tracing::warn!(server = %name, error = %e, "failed to connect, skipping");
+                        eng.failed.lock().await.push((name, e.to_string()));
+                    }
+                }
+                eng.pending.fetch_sub(1, Ordering::SeqCst);
+            });
+        }
+
         Ok(())
     }
 
     /// Get a summary of the connected servers and tools.
     pub async fn summary(&self) -> String {
+        let pending = self.pending.load(Ordering::SeqCst);
+        let total = self.total_servers.load(Ordering::SeqCst);
         let state = self.state.lock().await;
-        match &*state {
-            EngineState::Ready(proxy_state) => proxy_state.catalog.summary(),
-            EngineState::Initializing { server_count } => {
-                format!("cmcp is initializing the upstream tool catalog for {server_count} configured MCP server(s)")
-            }
-            EngineState::Failed { server_count, error } => {
-                format!("cmcp initialization failed for {server_count} configured MCP server(s): {error}")
-            }
+        let catalog = state.catalog.read().await;
+        let mut s = catalog.summary();
+        if pending > 0 {
+            let ready = total.saturating_sub(pending);
+            s = format!("{s} ({ready} of {total} server(s) connected, {pending} still loading)");
         }
+        s
     }
 
     /// Get the number of tools in the catalog.
     pub async fn tool_count(&self) -> usize {
         let state = self.state.lock().await;
-        match &*state {
-            EngineState::Ready(proxy_state) => proxy_state.catalog.entries().len(),
-            _ => 0,
-        }
+        let catalog = state.catalog.read().await;
+        catalog.entries().len()
     }
 
     /// Get tool names grouped by server, sorted alphabetically.
     pub async fn catalog_entries_by_server(&self) -> std::collections::BTreeMap<String, Vec<String>> {
         let state = self.state.lock().await;
-        match &*state {
-            EngineState::Ready(proxy_state) => {
-                let mut servers: std::collections::BTreeMap<String, Vec<String>> =
-                    std::collections::BTreeMap::new();
-                for entry in proxy_state.catalog.entries() {
-                    servers
-                        .entry(entry.server.clone())
-                        .or_default()
-                        .push(entry.name.clone());
-                }
-                servers
-            }
-            _ => std::collections::BTreeMap::new(),
+        let catalog = state.catalog.read().await;
+        let mut servers: std::collections::BTreeMap<String, Vec<String>> =
+            std::collections::BTreeMap::new();
+        for entry in catalog.entries() {
+            servers
+                .entry(entry.server.clone())
+                .or_default()
+                .push(entry.name.clone());
         }
+        servers
     }
 }
 
 impl ProxyState {
     async fn new(servers: HashMap<String, ServerConfig>) -> Result<Self> {
         let (pool, catalog) = ClientPool::connect(servers).await?;
-        let catalog = Arc::new(catalog);
+        let catalog = Arc::new(RwLock::new(catalog));
         let pool = Arc::new(pool);
         let sandbox = Sandbox::new(pool.clone(), catalog.clone()).await?;
         Ok(Self {
@@ -301,53 +371,63 @@ mod tests {
     use tokio::time::{sleep, timeout};
 
     #[tokio::test]
-    async fn starting_search_returns_retryable_initializing_error() {
-        let engine = ProxyEngine::starting(3);
+    async fn starting_search_returns_empty_with_pending_note() {
+        let engine = ProxyEngine::starting(3).await;
 
-        let error = engine
+        let result = engine
             .search("return tools;", None)
             .await
-            .expect_err("search should fail while the engine is initializing");
-        let message = error.to_string();
+            .expect("search should succeed immediately with incremental loading");
 
-        assert!(message.contains("still initializing"));
-        assert!(message.contains("3 configured MCP server(s)"));
+        assert!(result.to_string().contains("still loading"));
+        assert!(engine.pending.load(Ordering::SeqCst) == 3);
     }
 
     #[tokio::test]
-    async fn starting_execute_returns_retryable_initializing_error() {
-        let engine = ProxyEngine::starting(2);
+    async fn starting_execute_returns_empty_with_pending_note() {
+        let engine = ProxyEngine::starting(2).await;
 
-        let error = engine
+        let result = engine
             .execute("return null;", None)
             .await
-            .expect_err("execute should fail while the engine is initializing");
-        let message = error.to_string();
+            .expect("execute should succeed immediately with incremental loading");
 
-        assert!(message.contains("still initializing"));
-        assert!(message.contains("2 configured MCP server(s)"));
+        assert!(result.text.contains("still loading"));
+        assert!(engine.pending.load(Ordering::SeqCst) == 2);
     }
 
     #[tokio::test]
-    async fn background_load_empty_config_becomes_ready() {
-        let engine = Arc::new(ProxyEngine::starting(0));
+    async fn background_load_empty_config_succeeds_immediately() {
+        let engine = Arc::new(ProxyEngine::starting(0).await);
         engine.start_background_load(HashMap::new());
 
         let result = timeout(Duration::from_secs(2), async {
-            loop {
-                match engine.search("return tools;", None).await {
-                    Ok(value) => break value,
-                    Err(error) if error.to_string().contains("still initializing") => {
-                        sleep(Duration::from_millis(10)).await;
-                    }
-                    Err(error) => panic!("unexpected search error: {error}"),
-                }
-            }
+            engine.search("return tools;", None).await
         })
         .await
-        .expect("background load did not complete");
+        .expect("search should complete immediately")
+        .expect("search should not error");
 
         assert_eq!(result, json!([]));
         assert_eq!(engine.tool_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn pending_count_decrements_on_empty_load() {
+        let engine = Arc::new(ProxyEngine::starting(0).await);
+        assert_eq!(engine.pending.load(Ordering::SeqCst), 0);
+
+        engine.start_background_load(HashMap::new());
+
+        timeout(Duration::from_secs(2), async {
+            loop {
+                if engine.pending.load(Ordering::SeqCst) == 0 {
+                    break;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("pending count should reach 0");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -915,10 +915,10 @@ async fn cmd_serve(config_path: Option<&PathBuf>) -> Result<()> {
 
     info!(
         server_count = cfg.servers.len(),
-        "connecting to upstream servers (user + project configs merged)"
+        "starting upstream server initialization in background (user + project configs merged)"
     );
 
-    let server = crate::server::CodeModeServer::new(cfg.servers, config_path.cloned()).await?;
+    let server = crate::server::CodeModeServer::new_background(cfg.servers, config_path.cloned());
 
     info!("starting MCP server on stdio (hot-reload enabled)");
     let service = server.serve(stdio()).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -918,7 +918,7 @@ async fn cmd_serve(config_path: Option<&PathBuf>) -> Result<()> {
         "starting upstream server initialization in background (user + project configs merged)"
     );
 
-    let server = crate::server::CodeModeServer::new_background(cfg.servers, config_path.cloned());
+    let server = crate::server::CodeModeServer::new_background(cfg.servers, config_path.cloned()).await;
 
     info!("starting MCP server on stdio (hot-reload enabled)");
     let service = server.serve(stdio()).await?;

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use rquickjs::context::EvalOptions;
 use rquickjs::prelude::Async;
 use rquickjs::{AsyncContext, AsyncRuntime, CatchResultExt, Function, Promise, Value, async_with};
+use tokio::sync::RwLock;
 use crate::catalog::Catalog;
 use crate::client::ClientPool;
 use crate::transpile;
@@ -14,7 +15,7 @@ pub struct Sandbox {
     rt: AsyncRuntime,
     ctx: AsyncContext,
     pool: Arc<ClientPool>,
-    catalog: Arc<Catalog>,
+    catalog: Arc<RwLock<Catalog>>,
 }
 
 fn eval_opts() -> EvalOptions {
@@ -47,7 +48,7 @@ const console = {
 "#;
 
 impl Sandbox {
-    pub async fn new(pool: Arc<ClientPool>, catalog: Arc<Catalog>) -> Result<Self> {
+    pub async fn new(pool: Arc<ClientPool>, catalog: Arc<RwLock<Catalog>>) -> Result<Self> {
         let rt = AsyncRuntime::new()?;
         rt.set_memory_limit(64 * 1024 * 1024).await; // 64 MB
         let ctx = AsyncContext::full(&rt).await?;
@@ -81,8 +82,11 @@ impl Sandbox {
 
     /// Execute a `search()` call — agent TypeScript code that filters the tool catalog.
     pub async fn search(&self, code: &str) -> Result<serde_json::Value> {
-        let catalog_json_str = serde_json::to_string(&self.catalog.to_json_value())?;
-        let code = transpile_agent_code(code, &self.catalog.type_declarations())?;
+        let catalog = self.catalog.read().await;
+        let catalog_json_str = serde_json::to_string(&catalog.to_json_value())?;
+        let type_decls = catalog.type_declarations();
+        drop(catalog);
+        let code = transpile_agent_code(code, &type_decls)?;
 
         let result = async_with!(self.ctx => |ctx| {
             let tools_val: Value = ctx.json_parse(catalog_json_str)
@@ -113,8 +117,19 @@ impl Sandbox {
     /// Execute an `execute()` call — agent TypeScript code that calls tools across servers.
     pub async fn execute(&self, code: &str) -> Result<serde_json::Value> {
         let pool = self.pool.clone();
-        let catalog = self.catalog.clone();
-        let code = transpile_agent_code(code, &self.catalog.type_declarations())?;
+        let _catalog = self.catalog.clone();
+        let catalog_guard = self.catalog.read().await;
+        let type_decls = catalog_guard.type_declarations();
+        let server_names: Vec<String> = catalog_guard.entries()
+            .iter()
+            .map(|e| e.server.clone())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        let catalog_json_str = serde_json::to_string(&catalog_guard.to_json_value())
+            .unwrap_or_else(|_| "[]".to_owned());
+        drop(catalog_guard);
+        let code = transpile_agent_code(code, &type_decls)?;
 
         let result = async_with!(self.ctx => |ctx| {
             // Inject __call_tool as an async native function.
@@ -151,16 +166,10 @@ impl Sandbox {
             // Build JS proxy objects for each server.
             let mut setup = String::new();
 
-            let mut server_names: Vec<&str> = catalog
-                .entries()
-                .iter()
-                .map(|e| e.server.as_str())
-                .collect::<std::collections::HashSet<_>>()
-                .into_iter()
-                .collect();
-            server_names.sort();
+            let mut sorted_server_names = server_names;
+            sorted_server_names.sort();
 
-            for name in &server_names {
+            for name in &sorted_server_names {
                 // Convert server names with hyphens to valid JS identifiers
                 // e.g. "chrome-devtools" -> "chrome_devtools"
                 let js_name = name.replace('-', "_");
@@ -179,9 +188,6 @@ impl Sandbox {
                 ));
             }
 
-            // Also inject the catalog
-            let catalog_json_str = serde_json::to_string(&catalog.to_json_value())
-                .unwrap_or_else(|_| "[]".to_owned());
             setup.push_str(&format!("const tools = {};", catalog_json_str));
 
             let wrapped = format!("(async () => {{ {setup}\n{code} }})()", setup = setup, code = code);
@@ -230,7 +236,7 @@ mod tests {
 
     async fn test_sandbox() -> Sandbox {
         let (pool, catalog) = ClientPool::connect(HashMap::new()).await.unwrap();
-        Sandbox::new(Arc::new(pool), Arc::new(catalog)).await.unwrap()
+        Sandbox::new(Arc::new(pool), Arc::new(RwLock::new(catalog))).await.unwrap()
     }
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -56,11 +56,12 @@ fn file_mtime(path: &PathBuf) -> Option<SystemTime> {
 }
 
 impl CodeModeServer {
-    pub async fn new(
+    pub fn new_background(
         servers: std::collections::HashMap<String, config::ServerConfig>,
         config_path: Option<PathBuf>,
-    ) -> anyhow::Result<Self> {
-        let engine = ProxyEngine::from_configs(servers).await?;
+    ) -> Self {
+        let engine = Arc::new(ProxyEngine::starting(servers.len()));
+        engine.start_background_load(servers);
 
         // Snapshot current config file mtimes.
         let user_mtime = config::default_config_path()
@@ -68,15 +69,15 @@ impl CodeModeServer {
             .and_then(|p| file_mtime(&p));
         let project_mtime = file_mtime(&config::project_config_path());
 
-        Ok(Self {
-            engine: Arc::new(engine),
+        Self {
+            engine,
             reload_state: Arc::new(Mutex::new(HotReloadState {
                 user_mtime,
                 project_mtime,
             })),
             config_path,
             tool_router: Self::tool_router(),
-        })
+        }
     }
 
     /// Check if config files have changed and reload if needed.

--- a/src/server.rs
+++ b/src/server.rs
@@ -56,11 +56,11 @@ fn file_mtime(path: &PathBuf) -> Option<SystemTime> {
 }
 
 impl CodeModeServer {
-    pub fn new_background(
+    pub async fn new_background(
         servers: std::collections::HashMap<String, config::ServerConfig>,
         config_path: Option<PathBuf>,
     ) -> Self {
-        let engine = Arc::new(ProxyEngine::starting(servers.len()));
+        let engine = Arc::new(ProxyEngine::starting(servers.len()).await);
         engine.start_background_load(servers);
 
         // Snapshot current config file mtimes.


### PR DESCRIPTION
Feat: Adds a feature that lets cmcp server start immediately while the mcp tools are loading in the background.

- Created initializing, ready, and failed engine states for background catalog loading.
- Returned initializing or failed errors from search and execute until the catalog is ready.
- Guarded background loads and reloads with generation checks to prevent stale state updates.
- Documented fast startup behavior in README.md and CLAUDE.md.